### PR TITLE
Clarify chart API contract and update tests

### DIFF
--- a/docs/chart_api_contract.md
+++ b/docs/chart_api_contract.md
@@ -1,0 +1,38 @@
+# Chart API Contract
+
+The `POST /v1/data/charts` endpoint returns analytical chart data for the
+requested chart type. Requests must include a JSON body matching the
+`ChartRequest` schema:
+
+```json
+{
+  "chart": "enps" | "nine_box",
+  "params": {}
+}
+```
+
+The response adheres to the `ChartResponse` schema:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `chart` | string | Identifier of the chart returned. |
+| `title` | string | Human readable title for the chart. |
+| `series` | list of `ChartSeries` | Data series for the chart. |
+| `legend` | list of string | Labels for the chart legend. |
+| `bins` | object or null | Optional summary values (e.g. totals). |
+| `insights_placeholder` | bool | Indicates whether insights are available. |
+
+`ChartSeries` objects contain a `name` and a list of `points`.  Each
+`SeriesPoint` includes `x` and `y` values and optional `meta` data:
+
+```json
+{
+  "name": "count",
+  "points": [
+    { "x": "2025-04", "y": 18, "meta": null }
+  ]
+}
+```
+
+This contract is considered canonical for chart responses and is used by
+the eNPS and 9-box chart implementations.

--- a/tests/test_charts_endpoint.py
+++ b/tests/test_charts_endpoint.py
@@ -13,12 +13,14 @@ async def test_enps_chart_contract():
         data = resp.json()
         assert isinstance(data.get("title"), str)
         assert isinstance(data.get("series"), list)
-        assert "counts" in data
+        assert isinstance(data.get("legend"), list)
+        assert "bins" in data
+        assert "insights_placeholder" in data
         # Check series shape
         if data["series"]:
             s = data["series"][0]
-            assert "label" in s
-            assert isinstance(s["label"], str)
+            assert "name" in s
+            assert isinstance(s["name"], str)
             assert "points" in s
             assert isinstance(s["points"], list)
             if s["points"]:
@@ -34,13 +36,17 @@ async def test_nine_box_chart_contract():
         assert resp.status_code == 200
         data = resp.json()
         assert isinstance(data.get("title"), str)
-        assert "grid" in data
-        assert "cells" in data
-        assert "legend" in data
-        # Check cells shape
-        if data["cells"]:
-            c = data["cells"][0]
-            assert "row" in c and "col" in c and "count" in c
-            assert isinstance(c["row"], int)
-            assert isinstance(c["col"], int)
-            assert isinstance(c["count"], int)
+        assert isinstance(data.get("series"), list)
+        assert isinstance(data.get("legend"), list)
+        assert "bins" in data
+        assert "insights_placeholder" in data
+        # Check series shape
+        if data["series"]:
+            s = data["series"][0]
+            assert "name" in s
+            assert isinstance(s["name"], str)
+            assert "points" in s
+            assert isinstance(s["points"], list)
+            if s["points"]:
+                pt = s["points"][0]
+                assert "x" in pt and "y" in pt


### PR DESCRIPTION
## Summary
- align chart endpoint tests with canonical `ChartResponse` fields
- document the chart API request and response contract

## Testing
- `PYTHONPATH=/workspace/hrpro-architecture pytest tests/test_charts_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4b19697e8832db0010f9d04fe8197