### PR TITLE
Use Field default factory for ChartRequest params

### DIFF
--- a/app/api/routers/charts.py
+++ b/app/api/routers/charts.py
@@ -1,6 +1,6 @@
 # app/api/routers/charts.py
 from fastapi import APIRouter
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Literal
 
 router = APIRouter(prefix="/v1/data", tags=["charts"])
@@ -8,7 +8,7 @@ router = APIRouter(prefix="/v1/data", tags=["charts"])
 
 class ChartRequest(BaseModel):
     chart: Literal["enps", "nine_box"]
-    params: dict = {}
+    params: dict = Field(default_factory=dict)
 
 
 class SeriesPoint(BaseModel):


### PR DESCRIPTION
## Summary
- avoid mutable default in `ChartRequest` by using `Field(default_factory=dict)`
- import `Field` from Pydantic

## Testing
- `PYTHONPATH=. pytest tests/test_charts_endpoint.py` *(fails: AssertionError expecting 'counts' in response; 'grid' missing)*
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68c4b1876648832d8b8242421583ac07