### PR TITLE
Consolidate advisor FastAPI app

### DIFF
--- a/app/advisor/main.py
+++ b/app/advisor/main.py
@@ -9,15 +9,12 @@ import json
 import uuid
 import time
 
-# create the app
-app = FastAPI()
-
-# include routers
-app.include_router(advisor.router)
-app.include_router(charts.router)
-
 
 app = FastAPI(title="HRPro Advisor API")
+
+# include routers after app creation
+app.include_router(advisor.router)
+app.include_router(charts.router)
 
 ADVISOR_SHAPE = {
     "summary": "",


### PR DESCRIPTION
## Summary
- initialize single FastAPI instance for advisor API
- include routers after app creation
- expose health and answer endpoints on the consolidated app

## Testing
- `python - <<'PY'
import types, sys
sys.modules['joblib'] = types.ModuleType('joblib')
sys.modules['numpy'] = types.ModuleType('numpy')
sys.modules['yaml'] = types.ModuleType('yaml')
scipy = types.ModuleType('scipy'); scipy.sparse = types.ModuleType('sparse'); scipy.sparse.load_npz=lambda *a, **k: None
sys.modules['scipy'] = scipy
sys.modules['scipy.sparse'] = scipy.sparse
adapter_mod = types.ModuleType('app.retrieval.adapter'); adapter_mod.retrieve=lambda *args, **kwargs: []
sys.modules['app.retrieval.adapter'] = adapter_mod
from fastapi.testclient import TestClient
from app.advisor.main import app
client = TestClient(app)
print('GET /health', client.get('/health').json())
body={'prompt':'test','module':'m','trace_id':'t','stream':False}
print('POST /v1/advisor/answer', client.post('/v1/advisor/answer', json=body).json())
PY`
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68c4b16c2384832da4d33430be6531f3