### PR TITLE
Remove duplicate export blocks in builder pages

### DIFF
--- a/app/ui/pages/2_PIP_Builder.py
+++ b/app/ui/pages/2_PIP_Builder.py
@@ -56,6 +56,3 @@ elif step == "Export":
         toast_success("Export succeeded!")
     except Exception as e:
         retry_banner(f"Export failed: {e}", lambda: toast_error("Retrying Export..."))
-    st.write(f"Payload for export: {payload}")
-    st.button("Export Plan")
-    st.success("Export available (stub)")

--- a/app/ui/pages/3_306090_Builder.py
+++ b/app/ui/pages/3_306090_Builder.py
@@ -61,9 +61,6 @@ elif step == "Export":
         toast_success("Export succeeded!")
     except Exception as e:
         retry_banner(f"Export failed: {e}", lambda: toast_error("Retrying Export..."))
-    st.write(f"Payload for export: {payload}")
-    st.button("Export Plan")
-    st.success("Export available (stub)")
 
 st.markdown("#### Quick Actions")
 actions = [


### PR DESCRIPTION
## Summary
- remove repeated export block in PIP Builder
- remove repeated export block in 30/60/90 Builder

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68c4ba51c8fc832db6c7eb019e3ecc67