### PR TITLE
chore: import FastAPI components in advisor

### DIFF
--- a/app/advisor/main.py
+++ b/app/advisor/main.py
@@ -1,13 +1,13 @@
+"""FastAPI application entrypoint for the Advisor service."""
+
+import json
+import time
+import uuid
+
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
-# import routers
-from app.api.routers import advisor
-from app.api.routers import charts
-
-import json
-import uuid
-import time
+from app.api.routers import advisor, charts
 
 
 app = FastAPI(title="HRPro Advisor API")


### PR DESCRIPTION
## Summary
- ensure advisor service defines `app = FastAPI(...)` before including routers
- explicitly import FastAPI utilities and routers in `app/advisor/main.py`

## Testing
- `pytest -q` (fails: ModuleNotFoundError: No module named 'app')
- `PYTHONPATH=. pytest -q` (fails: SystemExit: 2 from tools.build_corpus.parse_args)


------
https://chatgpt.com/codex/tasks/task_e_68c4ba4d201c832dbbeee73d700764e6