### PR TITLE
Ensure advisor endpoint returns AdvisorResponse

### DIFF
--- a/app/api/routers/advisor.py
+++ b/app/api/routers/advisor.py
@@ -28,7 +28,7 @@ class AdvisorRequest(BaseModel):
 
 
 @router.post("/answer", response_model=AdvisorResponse)
-def advisor_answer(req: AdvisorRequest):
+def advisor_answer(req: AdvisorRequest) -> AdvisorResponse:
     t0 = time.perf_counter()
     # Simulate summary, findings, etc.
     summary = f"Stub summary for: {req.prompt}"


### PR DESCRIPTION
## Summary
- annotate the `/v1/advisor/answer` endpoint to return `AdvisorResponse`
- confirm FastAPI/Pydantic and typing imports in advisor router

## Testing
- `PYTHONPATH=. pytest tests/test_advisor_with_retrieval.py::test_advisor_returns_attributions -vv` *(fails: assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ba4abad0832d9cb98e569e2fe1fc