### PR TITLE
refactor: organize imports for charts router

### DIFF
--- a/app/api/routers/charts.py
+++ b/app/api/routers/charts.py
@@ -1,7 +1,8 @@
 # app/api/routers/charts.py
+from typing import List, Literal
+
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
-from typing import List, Literal
 
 router = APIRouter(prefix="/v1/data", tags=["charts"])
 


### PR DESCRIPTION
## Summary
- organize imports in charts router to explicitly include `APIRouter`, `BaseModel`, `Field`, `Literal`, and `List`
- verify `/v1/data/charts` endpoint enforces request schema

## Testing
- `PYTHONPATH=. pytest tests/test_charts_endpoint.py -q`
- `python - <<'PY'
import asyncio
from httpx import AsyncClient
from asgi_lifespan import LifespanManager
from app.api.main import app

async def main():
    async with LifespanManager(app):
        async with AsyncClient(app=app, base_url="http://test") as ac:
            resp_missing = await ac.post("/v1/data/charts", json={})
            print('missing chart status', resp_missing.status_code)
            print(resp_missing.json())
            resp_invalid = await ac.post("/v1/data/charts", json={"chart": "something"})
            print('invalid chart status', resp_invalid.status_code)
            print(resp_invalid.json())
asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c4ba48116c832d8a756e11bbcff82c