### PR TITLE
Handle disabled query rewrite

### DIFF
--- a/app/retrieval/adapter.py
+++ b/app/retrieval/adapter.py
@@ -1,5 +1,5 @@
-import joblib
 import json
+import joblib
 import numpy as np
 from pathlib import Path
 from scipy import sparse
@@ -78,6 +78,10 @@ def retrieve(topic: str, top_k: int = 5):
         rewrite_out = rewrite(topic, anchor_aliases)
         expanded_query = rewrite_out.get("expanded_query", topic)
         # All imports are at the top of the file
+        must_have = []
+        nice_to_have = []
+    else:
+        expanded_query = topic
         must_have = []
         nice_to_have = []
     # Synonym expansion


### PR DESCRIPTION
## Summary
- ensure retrieval initializes query and constraints when query rewriting is disabled
- keep imports for json and joblib at top of adapter module

## Testing
- `ruff check app/retrieval/adapter.py`
- `ruff format app/retrieval/adapter.py`
- `black app/retrieval/adapter.py`
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68c4ba461958832daf23eebb357bf802