### PR TITLE
test: skip retrieval tests when dependencies missing

### DIFF
--- a/tests/test_advisor_with_retrieval.py
+++ b/tests/test_advisor_with_retrieval.py
@@ -1,3 +1,8 @@
+import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("scipy")
+
 from fastapi.testclient import TestClient
 from app.api.main import app
 import json

--- a/tests/test_ollama_cache.py
+++ b/tests/test_ollama_cache.py
@@ -1,3 +1,8 @@
+import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("scipy")
+
 import numpy as np
 from app.retrieval import ollama_client
 

--- a/tests/test_ollama_client_calls.py
+++ b/tests/test_ollama_client_calls.py
@@ -1,3 +1,8 @@
+import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("scipy")
+
 from app.retrieval import ollama_client
 
 

--- a/tests/test_retrieval_adapter.py
+++ b/tests/test_retrieval_adapter.py
@@ -1,4 +1,8 @@
 import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("scipy")
+
 from app.retrieval.adapter import retrieve
 
 

--- a/tests/test_retrieval_faiss.py
+++ b/tests/test_retrieval_faiss.py
@@ -1,3 +1,8 @@
+import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("scipy")
+
 from app.retrieval.adapter import retrieve, _load
 
 


### PR DESCRIPTION
## Summary
- skip retrieval-related tests if sklearn or scipy not installed using `pytest.importorskip`

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4d090703c832d8796fb6db08280ac