### PR TITLE
Add ML packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ pytest==8.3.2
 pytest-asyncio==0.23.8
 asgi-lifespan==2.1.0
 typing-extensions==4.12.2
+
+joblib==1.4.2
+scikit-learn==1.4.2
+scipy==1.12.0


### PR DESCRIPTION
## Summary
- include joblib, scikit-learn, and scipy in requirements for retrieval features

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement joblib==1.4.2 due to proxy restrictions)*
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68c4d08f3f50832da0927a53415ffc8a