### PR TITLE
Add fallback to heuristic rerank on Ollama failure

### DIFF
--- a/tests/test_rerank_fallback.py
+++ b/tests/test_rerank_fallback.py
@@ -1,0 +1,47 @@
+import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("scipy")
+
+import sys
+import types
+
+import requests
+
+from app.services import telemetry
+
+
+def test_ollama_rerank_fallback(monkeypatch, tmp_path):
+    """When Ollama is unreachable, heuristic scores are returned and logged."""
+
+    monkeypatch.setitem(
+        sys.modules,
+        "yaml",
+        types.SimpleNamespace(
+            safe_load=lambda f: {"ollama": {"endpoint": "http://x", "model": "m"}}
+        ),
+    )
+    from app.retrieval import rerank as rerank_mod
+
+    def boom(*args, **kwargs):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(rerank_mod.requests, "post", boom)
+    monkeypatch.setattr(telemetry, "LOG_DIR", tmp_path, raising=False)
+    telemetry.LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    query = "test"
+    candidates = [
+        {"section": "alpha", "snippet": "alpha snippet"},
+        {"section": "beta", "snippet": "beta snippet"},
+    ]
+
+    expected = rerank_mod.heuristic_rerank(query, candidates)
+    scores = rerank_mod.ollama_rerank(query, candidates)
+
+    assert scores == expected
+
+    log_file = tmp_path / "retrieval.jsonl"
+    lines = log_file.read_text().splitlines()
+    assert any("ollama_rerank_fallback" in line for line in lines)
+


### PR DESCRIPTION
## Summary
- handle `requests.post` failures in `ollama_rerank` by logging telemetry and falling back to `heuristic_rerank`
- test that unreachable Ollama returns heuristic scores and emits a fallback telemetry event

## Testing
- `ruff check app/retrieval/rerank.py tests/test_rerank_fallback.py`
- `pytest -q` *(fails: unrecognized arguments passed to tools/build_corpus.py)*
- `pytest tests/test_rerank_fallback.py tests/test_telemetry.py tests/test_ollama_client_calls.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c632f47048832da2b0b198d0db9294