### PR TITLE
Add dependency checks to readiness probe

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse, PlainTextResponse
 
 from app.api.routers import advisor, charts
+from app.retrieval import adapter, ollama_client
 
 app = FastAPI(title="HRPro API")
 app.include_router(charts.router)
@@ -14,6 +15,26 @@ def healthz() -> str:
 
 
 @app.get("/readyz", response_class=JSONResponse, tags=["ops"])  # readiness
-def readyz() -> dict:
-    # Lightweight readiness; can be extended to check external deps
-    return {"status": "ready"}
+def readyz() -> JSONResponse:
+    """Check external dependencies for readiness."""
+    errors: list[str] = []
+
+    if not ollama_client.health_ok():
+        errors.append("ollama_client not healthy")
+
+    required = [
+        adapter.META_PATH,
+        adapter.MATRIX_PATH,
+        adapter.VEC_PATH,
+        adapter.NN_PATH,
+    ]
+    missing = [p.name for p in required if not p.exists()]
+    if missing:
+        errors.append(f"missing index files: {', '.join(sorted(missing))}")
+
+    if errors:
+        return JSONResponse(
+            status_code=503, content={"status": "not ready", "errors": errors}
+        )
+
+    return JSONResponse(content={"status": "ready"})

--- a/tests/test_readyz.py
+++ b/tests/test_readyz.py
@@ -1,0 +1,77 @@
+import sys
+import types
+
+from asgi_lifespan import LifespanManager
+from httpx import AsyncClient
+import pytest
+
+# Provide minimal yaml stub to satisfy imports when PyYAML is missing
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda *a, **kw: {}
+yaml_stub.dump = lambda *a, **kw: None
+sys.modules.setdefault("yaml", yaml_stub)
+
+from app.api.main import app
+from app.retrieval import adapter, ollama_client
+
+
+@pytest.mark.asyncio
+async def test_readyz_success(tmp_path, monkeypatch):
+    # Create required index files
+    files = {
+        "meta.json",
+        "matrix.npz",
+        "tfidf.joblib",
+        "nn.joblib",
+    }
+    for name in files:
+        (tmp_path / name).write_text("x")
+
+    monkeypatch.setattr(adapter, "META_PATH", tmp_path / "meta.json")
+    monkeypatch.setattr(adapter, "MATRIX_PATH", tmp_path / "matrix.npz")
+    monkeypatch.setattr(adapter, "VEC_PATH", tmp_path / "tfidf.joblib")
+    monkeypatch.setattr(adapter, "NN_PATH", tmp_path / "nn.joblib")
+    monkeypatch.setattr(ollama_client, "health_ok", lambda: True)
+
+    async with LifespanManager(app):
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            resp = await ac.get("/readyz")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_readyz_ollama_failure(tmp_path, monkeypatch):
+    for name in ["meta.json", "matrix.npz", "tfidf.joblib", "nn.joblib"]:
+        (tmp_path / name).write_text("x")
+    monkeypatch.setattr(adapter, "META_PATH", tmp_path / "meta.json")
+    monkeypatch.setattr(adapter, "MATRIX_PATH", tmp_path / "matrix.npz")
+    monkeypatch.setattr(adapter, "VEC_PATH", tmp_path / "tfidf.joblib")
+    monkeypatch.setattr(adapter, "NN_PATH", tmp_path / "nn.joblib")
+    monkeypatch.setattr(ollama_client, "health_ok", lambda: False)
+
+    async with LifespanManager(app):
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            resp = await ac.get("/readyz")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "not ready"
+    assert any("ollama" in e for e in body["errors"])
+
+
+@pytest.mark.asyncio
+async def test_readyz_missing_index(monkeypatch, tmp_path):
+    # don't create index files to trigger missing
+    monkeypatch.setattr(adapter, "META_PATH", tmp_path / "meta.json")
+    monkeypatch.setattr(adapter, "MATRIX_PATH", tmp_path / "matrix.npz")
+    monkeypatch.setattr(adapter, "VEC_PATH", tmp_path / "tfidf.joblib")
+    monkeypatch.setattr(adapter, "NN_PATH", tmp_path / "nn.joblib")
+    monkeypatch.setattr(ollama_client, "health_ok", lambda: True)
+
+    async with LifespanManager(app):
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            resp = await ac.get("/readyz")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "not ready"
+    assert any("missing index files" in e for e in body["errors"])


### PR DESCRIPTION
## Summary
- verify Ollama and retrieval index in `/readyz`
- return HTTP 503 with details if dependencies fail
- add tests for readiness success and failure scenarios

## Testing
- `ruff check --fix app/api/main.py tests/test_readyz.py`
- `ruff format app/api/main.py tests/test_readyz.py`
- `black app/api/main.py tests/test_readyz.py`
- `mypy app/api/main.py` *(fails: Library stubs not installed for "requests" etc.)*
- `bandit -c bandit.yaml -q app/api/main.py` *(fails: command not found)*
- `pytest tests/test_readyz.py`


------
https://chatgpt.com/codex/tasks/task_e_68c751c364d8832d99c96f51fa56e457