### PR TITLE
Cache retrieval corpus and emit telemetry

### DIFF
--- a/app/retrieval/query_rewrite.py
+++ b/app/retrieval/query_rewrite.py
@@ -6,14 +6,11 @@ import re
 import yaml
 
 from app.retrieval import ollama_client
-
-TELEMETRY_PATH = Path(__file__).parent.parent.parent / "logs/dev_telemetry.jsonl"
+from app.services import telemetry
 
 
 def _log_event(event, **kwargs):
-    line = json.dumps({"event": event, **kwargs})
-    with open(TELEMETRY_PATH, "a") as f:
-        f.write(line + "\n")
+    telemetry.emit("retrieval", {"event": event, **kwargs})
 
 
 def _extract_json(text):


### PR DESCRIPTION
## Summary
- cache corpus lines once during retrieval adapter load to avoid repeated reads
- route retrieval and query-rewrite events through telemetry service instead of writing files

## Testing
- `pytest tests/test_retrieval_adapter.py::test_retrieve_nonempty -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*
- `pytest tests/test_telemetry.py -q`
- `python -m py_compile app/retrieval/adapter.py app/retrieval/query_rewrite.py`


------
https://chatgpt.com/codex/tasks/task_e_68c751c7565c832d94dc244c3499aaa0