### PR TITLE
Batch Ollama rerank requests and add tests

### DIFF
--- a/tests/test_ollama_batch.py
+++ b/tests/test_ollama_batch.py
@@ -1,0 +1,45 @@
+import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("scipy")
+
+import sys
+import types
+
+
+def test_ollama_rerank_batch(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "yaml",
+        types.SimpleNamespace(
+            safe_load=lambda f: {"ollama": {"endpoint": "http://x", "model": "m"}}
+        ),
+    )
+    from app.retrieval import rerank as rerank_mod
+
+    class DummyResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"responses": ["0.5", "0.25"]}
+
+    calls = {"count": 0}
+
+    def fake_post(url, json, timeout):
+        calls["count"] += 1
+        assert isinstance(json.get("passages"), list)
+        return DummyResp()
+
+    monkeypatch.setattr(rerank_mod.requests, "post", fake_post)
+
+    query = "test"
+    candidates = [
+        {"section": "alpha", "snippet": "alpha snippet"},
+        {"section": "beta", "snippet": "beta snippet"},
+    ]
+
+    scores = rerank_mod.ollama_rerank(query, candidates)
+
+    assert scores == [0.5, 0.25]
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- send all candidate passages to Ollama in a single request and parse batch scores
- fall back to heuristic reranker when the batch call fails
- add test covering batch rerank behavior

## Testing
- `pytest tests/test_ollama_batch.py tests/test_rerank_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c751cae034832d803f96b05298a13e